### PR TITLE
FIL001-138: accept a closure in AttachmentInput::allowedFormats()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### What's Changed
 
+* FIL001-138 `AttachmentInput::allowedFormats()` now accepts a closure, so the cropper formats can depend on other fields (`fn (Get $get) => ...`). Previously only arrays were accepted, even though `UploadAttachmentAction::allowedFormats()` already took closures.
 * E20-137 Add attachment versioning: replace files and revert to previous versions
 * `EditAttachment` now declares its header actions through `getHeaderActions()` instead of the deprecated `getActions()` hook. No visible change: the `DeleteAction` was already rendered through the deprecated path.
 * `Attachment::$url` now carries a `?v={version}` cache buster once a file has been replaced, so a replacement with an identical filename is no longer served from cache. Temporary (signed) urls are unaffected.

--- a/docs/index.md
+++ b/docs/index.md
@@ -398,6 +398,21 @@ AttachmentInput::make('profile_image_id')
     ])
 ```
 
+The method also accepts a closure, so the formats can depend on other fields in the same schema. This is useful in an Architect block where the rendered format is chosen by another field:
+
+```php
+use App\Formats\Landscape;
+use App\Formats\Portrait;
+use Filament\Schemas\Components\Utilities\Get;
+use Wotz\MediaLibrary\Components\Fields\AttachmentInput;
+
+AttachmentInput::make('image_id')
+    ->allowedFormats(fn (Get $get) => match ($get('orientation')) {
+        'portrait' => [Portrait::class],
+        default => [Landscape::class],
+    })
+```
+
 ### AttachmentColumn
 
 This column for a table will render the image with the thumbnail format or an icon if attachment is not an image.

--- a/src/Filament/AttachmentInput.php
+++ b/src/Filament/AttachmentInput.php
@@ -27,7 +27,7 @@ class AttachmentInput extends Field
 
     protected null|string|Closure $sortField = null;
 
-    protected ?array $allowedFormats = null;
+    protected null|array|Closure $allowedFormats = null;
 
     protected function setUp(): void
     {
@@ -234,7 +234,10 @@ class AttachmentInput extends Field
         return $this->evaluate($this->sortField);
     }
 
-    public function allowedFormats(?array $allowedFormats): static
+    /**
+     * @param  array<int, string|Format>|Closure|null  $allowedFormats
+     */
+    public function allowedFormats(null|array|Closure $allowedFormats): static
     {
         $this->allowedFormats = $allowedFormats;
 

--- a/tests/Feature/Filament/AttachmentInputTest.php
+++ b/tests/Feature/Filament/AttachmentInputTest.php
@@ -4,6 +4,7 @@ use Filament\Actions\Testing\TestAction;
 use Livewire\Livewire;
 use Wotz\MediaLibrary\Filament\AttachmentInput;
 use Wotz\MediaLibrary\Tests\Fixtures\Livewire\AttachmentInputComponent;
+use Wotz\MediaLibrary\Tests\Fixtures\Livewire\ConditionalFormatsAttachmentInputComponent;
 use Wotz\MediaLibrary\Tests\Fixtures\TestFormats\TestBanner;
 use Wotz\MediaLibrary\Tests\Fixtures\TestFormats\TestHero;
 
@@ -12,6 +13,22 @@ it('hints at the minimum source size and the format count', function () {
         ->allowedFormats([TestHero::class, TestBanner::class]);
 
     expect($field->getHint())->toBe('at least 200 × 100 px · 2 formats');
+});
+
+it('accepts a closure for the allowed formats', function () {
+    $field = AttachmentInput::make('image')
+        ->allowedFormats(fn (): array => [TestHero::class]);
+
+    expect($field->getAllowedFormats())->toBe([TestHero::class])
+        ->and($field->getHint())->toBe('100 × 100 px');
+});
+
+it('resolves closure formats against sibling fields', function () {
+    Livewire::test(ConditionalFormatsAttachmentInputComponent::class)
+        ->assertSee('200 × 50 px')
+        ->set('data.orientation', 'portrait')
+        ->assertSee('100 × 100 px')
+        ->assertDontSee('200 × 50 px');
 });
 
 it('hints nothing when no formats apply', function (AttachmentInput $field) {

--- a/tests/Fixtures/Livewire/ConditionalFormatsAttachmentInputComponent.php
+++ b/tests/Fixtures/Livewire/ConditionalFormatsAttachmentInputComponent.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Wotz\MediaLibrary\Tests\Fixtures\Livewire;
+
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Schemas\Schema;
+use Livewire\Component;
+use Wotz\MediaLibrary\Filament\AttachmentInput;
+use Wotz\MediaLibrary\Tests\Fixtures\TestFormats\TestBanner;
+use Wotz\MediaLibrary\Tests\Fixtures\TestFormats\TestHero;
+
+/**
+ * Hosts an AttachmentInput whose allowed formats follow a sibling select, the way an
+ * Architect block picks the rendered format from another field.
+ */
+class ConditionalFormatsAttachmentInputComponent extends Component implements HasActions, HasSchemas
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+
+    /** @var array<string, mixed> */
+    public array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill(['orientation' => 'landscape', 'image' => null]);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('orientation')
+                    ->options(['landscape' => 'Landscape', 'portrait' => 'Portrait'])
+                    ->live(),
+
+                AttachmentInput::make('image')
+                    ->allowedFormats(fn (Get $get): array => match ($get('orientation')) {
+                        'portrait' => [TestHero::class],
+                        default => [TestBanner::class],
+                    }),
+            ])
+            ->statePath('data');
+    }
+
+    public function render(): string
+    {
+        return '<div>{{ $this->form }}<x-filament-actions::modals /></div>';
+    }
+}


### PR DESCRIPTION
getAllowedFormats() already evaluated the value, but the setter only accepted arrays, so formats could not follow sibling fields (fn (Get $get) => ...). UploadAttachmentAction::allowedFormats() already took closures.