### PR TITLE
Make the attachment model configurable

### DIFF
--- a/config/filament-media-library.php
+++ b/config/filament-media-library.php
@@ -3,6 +3,12 @@
 use Wotz\MediaLibrary\Conversions\LocalConversion;
 
 return [
+    // Point this at a subclass of Wotz\MediaLibrary\Models\Attachment to
+    // change how attachments behave — overriding the root directory, for
+    // instance, so an application can keep an existing storage layout.
+    // Null uses the package's own model.
+    'model' => null,
+
     'conversion' => LocalConversion::class,
     'enable-format-generate-action' => true,
     'force-format-extension' => [

--- a/src/Commands/GenerateFormats.php
+++ b/src/Commands/GenerateFormats.php
@@ -7,6 +7,7 @@ use Wotz\MediaLibrary\Facades\Formats;
 use Wotz\MediaLibrary\Formats\Format;
 use Wotz\MediaLibrary\Jobs\GenerateAttachmentFormat;
 use Wotz\MediaLibrary\Models\Attachment;
+use Wotz\MediaLibrary\Support\Config;
 
 class GenerateFormats extends Command
 {
@@ -34,7 +35,7 @@ class GenerateFormats extends Command
             fn ($formats) => $formats->only($this->option('format'))
         );
 
-        $attachments = Attachment::query()
+        $attachments = Config::attachmentQuery()
             ->when(
                 $this->option('attachment-id'),
                 fn ($query) => $query->where('id', $this->option('attachment-id'))

--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Wotz\MediaLibrary\Exceptions;
+
+use Exception;
+use Wotz\MediaLibrary\Models\Attachment;
+
+class InvalidConfiguration extends Exception
+{
+    public static function modelIsNotValid(string $model): self
+    {
+        return new static(
+            "The configured attachment model `{$model}` is invalid. "
+            . 'A valid model must be a subclass of `' . Attachment::class . '`.'
+        );
+    }
+}

--- a/src/Filament/Actions/Forms/UploadAttachmentAction.php
+++ b/src/Filament/Actions/Forms/UploadAttachmentAction.php
@@ -8,6 +8,7 @@ use Filament\Schemas\Components\Utilities\Set;
 use Livewire\Component;
 use Wotz\MediaLibrary\Filament\Actions\Traits\CanUploadAttachment;
 use Wotz\MediaLibrary\Models\Attachment;
+use Wotz\MediaLibrary\Support\Config;
 
 class UploadAttachmentAction extends Action
 {
@@ -25,7 +26,7 @@ class UploadAttachmentAction extends Action
 
                 $attachmentIds = collect($data['attachments'] ?? [])
                     ->map(function (string $attachmentId) use ($data) {
-                        $attachment = Attachment::find($attachmentId);
+                        $attachment = Config::attachmentModel()::find($attachmentId);
 
                         if (! $attachment) {
                             return null;

--- a/src/Filament/Actions/Traits/CanUploadAttachment.php
+++ b/src/Filament/Actions/Traits/CanUploadAttachment.php
@@ -17,11 +17,11 @@ use Illuminate\Support\Arr;
 use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Wotz\MediaLibrary\Formats\Format;
-use Wotz\MediaLibrary\Models\Attachment;
 use Wotz\MediaLibrary\Models\AttachmentTag;
 use Wotz\MediaLibrary\Rules\FileRule;
 use Wotz\MediaLibrary\Support\FormatSummary;
 use Wotz\TranslatableTabs\Forms\TranslatableTabs;
+use Wotz\MediaLibrary\Support\Config;
 
 trait CanUploadAttachment
 {
@@ -255,7 +255,7 @@ trait CanUploadAttachment
 
         collect($data['attachments'] ?? [])
             ->map(function (string $attachmentId) use ($data) {
-                $attachment = Attachment::find($attachmentId);
+                $attachment = Config::attachmentModel()::find($attachmentId);
 
                 if (! $attachment) {
                     return null;

--- a/src/Filament/Actions/Traits/CanUploadAttachment.php
+++ b/src/Filament/Actions/Traits/CanUploadAttachment.php
@@ -19,9 +19,9 @@ use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Wotz\MediaLibrary\Formats\Format;
 use Wotz\MediaLibrary\Models\AttachmentTag;
 use Wotz\MediaLibrary\Rules\FileRule;
+use Wotz\MediaLibrary\Support\Config;
 use Wotz\MediaLibrary\Support\FormatSummary;
 use Wotz\TranslatableTabs\Forms\TranslatableTabs;
-use Wotz\MediaLibrary\Support\Config;
 
 trait CanUploadAttachment
 {

--- a/src/Filament/AttachmentInput.php
+++ b/src/Filament/AttachmentInput.php
@@ -14,10 +14,10 @@ use Livewire\Component;
 use Wotz\MediaLibrary\Facades\Formats;
 use Wotz\MediaLibrary\Filament\Actions\Forms\UploadAttachmentAction;
 use Wotz\MediaLibrary\Formats\Format;
-use Wotz\MediaLibrary\Models\Attachment;
 use Wotz\MediaLibrary\Models\AttachmentTag;
 use Wotz\MediaLibrary\Resources\AttachmentResource;
 use Wotz\MediaLibrary\Support\FormatSummary;
+use Wotz\MediaLibrary\Support\Config;
 
 class AttachmentInput extends Field
 {
@@ -212,7 +212,7 @@ class AttachmentInput extends Field
             ->map(fn ($id) => "'{$id}'")
             ->join(',');
 
-        return Attachment::whereIn('id', Arr::wrap($state))
+        return Config::attachmentQuery()->whereIn('id', Arr::wrap($state))
             ->orderByRaw("FIELD(id,{$ids})")
             ->get();
     }

--- a/src/Filament/AttachmentInput.php
+++ b/src/Filament/AttachmentInput.php
@@ -16,8 +16,8 @@ use Wotz\MediaLibrary\Filament\Actions\Forms\UploadAttachmentAction;
 use Wotz\MediaLibrary\Formats\Format;
 use Wotz\MediaLibrary\Models\AttachmentTag;
 use Wotz\MediaLibrary\Resources\AttachmentResource;
-use Wotz\MediaLibrary\Support\FormatSummary;
 use Wotz\MediaLibrary\Support\Config;
+use Wotz\MediaLibrary\Support\FormatSummary;
 
 class AttachmentInput extends Field
 {

--- a/src/Livewire/FormatterModal.php
+++ b/src/Livewire/FormatterModal.php
@@ -10,6 +10,7 @@ use Spatie\Image\Image;
 use Wotz\MediaLibrary\Facades\Formats;
 use Wotz\MediaLibrary\Formats\Format;
 use Wotz\MediaLibrary\Models\Attachment;
+use Wotz\MediaLibrary\Support\Config;
 
 class FormatterModal extends Component
 {
@@ -24,7 +25,7 @@ class FormatterModal extends Component
     #[On('filament-media-library::open-formatter-attachment-modal')]
     public function setAttachment(string $uuid, ?array $formats = null)
     {
-        $this->attachment = Attachment::find($uuid);
+        $this->attachment = Config::attachmentModel()::find($uuid);
 
         $this->forcedMimeType = config(
             'filament-media-library.force-format-extension.mime-type',

--- a/src/Mixins/UploadedFileMixin.php
+++ b/src/Mixins/UploadedFileMixin.php
@@ -10,6 +10,7 @@ use Wotz\MediaLibrary\Facades\Formats;
 use Wotz\MediaLibrary\Formats\Thumbnail;
 use Wotz\MediaLibrary\Jobs\GenerateAttachmentFormat;
 use Wotz\MediaLibrary\Models\Attachment;
+use Wotz\MediaLibrary\Support\Config;
 
 /**
  * @mixin TemporaryUploadedFile
@@ -43,7 +44,7 @@ class UploadedFileMixin
             ];
 
             /** @var Attachment $attachment */
-            $attachment = Attachment::firstOrCreate([
+            $attachment = Config::attachmentModel()::firstOrCreate([
                 'md5' => $data['md5'],
             ], $data);
 

--- a/src/Models/Attachment.php
+++ b/src/Models/Attachment.php
@@ -39,6 +39,10 @@ class Attachment extends Model
     use HasUuids;
     use HasVersions;
 
+    // Declared rather than guessed from the class name, so a configured
+    // subclass can be called anything without pointing at a missing table.
+    protected $table = 'attachments';
+
     protected $keyType = 'string';
 
     protected $fillable = [

--- a/src/Models/AttachmentFormat.php
+++ b/src/Models/AttachmentFormat.php
@@ -5,6 +5,7 @@ namespace Wotz\MediaLibrary\Models;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Wotz\MediaLibrary\Support\Config;
 
 /**
  * @property string $attachment_id
@@ -26,6 +27,6 @@ class AttachmentFormat extends Model
 
     public function attachment(): BelongsTo
     {
-        return $this->belongsTo(Attachment::class);
+        return $this->belongsTo(Config::attachmentModel());
     }
 }

--- a/src/Models/AttachmentVersion.php
+++ b/src/Models/AttachmentVersion.php
@@ -5,6 +5,7 @@ namespace Wotz\MediaLibrary\Models;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Wotz\MediaLibrary\Support\Config;
 
 /**
  * @property int $id
@@ -54,7 +55,7 @@ class AttachmentVersion extends Model
 
     public function attachment(): BelongsTo
     {
-        return $this->belongsTo(Attachment::class);
+        return $this->belongsTo(Config::attachmentModel());
     }
 
     public function getFilenameAttribute(): string

--- a/src/Resources/AttachmentResource.php
+++ b/src/Resources/AttachmentResource.php
@@ -31,8 +31,8 @@ use Wotz\MediaLibrary\Formats\Format;
 use Wotz\MediaLibrary\Jobs\GenerateAttachmentFormat;
 use Wotz\MediaLibrary\Models\Attachment;
 use Wotz\MediaLibrary\Resources\AttachmentResource\Pages;
-use Wotz\TranslatableTabs\Forms\TranslatableTabs;
 use Wotz\MediaLibrary\Support\Config;
+use Wotz\TranslatableTabs\Forms\TranslatableTabs;
 
 class AttachmentResource extends Resource
 {

--- a/src/Resources/AttachmentResource.php
+++ b/src/Resources/AttachmentResource.php
@@ -32,10 +32,16 @@ use Wotz\MediaLibrary\Jobs\GenerateAttachmentFormat;
 use Wotz\MediaLibrary\Models\Attachment;
 use Wotz\MediaLibrary\Resources\AttachmentResource\Pages;
 use Wotz\TranslatableTabs\Forms\TranslatableTabs;
+use Wotz\MediaLibrary\Support\Config;
 
 class AttachmentResource extends Resource
 {
-    protected static ?string $model = Attachment::class;
+    // Resolved rather than declared: a static property cannot call config(),
+    // and the resource must use the same model as the rest of the package.
+    public static function getModel(): string
+    {
+        return Config::attachmentModel();
+    }
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-paper-clip';
 
@@ -150,7 +156,7 @@ class AttachmentResource extends Resource
             ->filters([
                 Filters\SelectFilter::make('disk')
                     ->label(__('filament-media-library::admin.disk'))
-                    ->options(fn () => Attachment::select('disk')
+                    ->options(fn () => Config::attachmentQuery()->select('disk')
                         ->groupBy('disk')
                         ->orderBy('disk')
                         ->pluck('disk')
@@ -160,7 +166,7 @@ class AttachmentResource extends Resource
 
                 Filters\SelectFilter::make('type')
                     ->label(__('filament-media-library::admin.type'))
-                    ->options(fn () => Attachment::select('type')
+                    ->options(fn () => Config::attachmentQuery()->select('type')
                         ->groupBy('type')
                         ->orderBy('type')
                         ->pluck('type')
@@ -176,7 +182,7 @@ class AttachmentResource extends Resource
 
                 Filters\SelectFilter::make('mime_type')
                     ->label(__('filament-media-library::admin.mime type'))
-                    ->options(fn () => Attachment::select('mime_type')
+                    ->options(fn () => Config::attachmentQuery()->select('mime_type')
                         ->groupBy('mime_type')
                         ->orderBy('mime_type')
                         ->pluck('mime_type')

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Wotz\MediaLibrary\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+use Wotz\MediaLibrary\Exceptions\InvalidConfiguration;
+use Wotz\MediaLibrary\Models\Attachment;
+
+/**
+ * Resolves the configured attachment model.
+ *
+ * An application can point `filament-media-library.model` at its own subclass
+ * to change how attachments behave — most usefully the root directory, so a
+ * project migrating from another media library can keep its existing storage
+ * layout instead of moving every object. Every place in this package that
+ * builds a query or creates a record goes through here, so a subclass applies
+ * to uploads and conversions too, not only to what the application reads back.
+ */
+class Config
+{
+    /**
+     * @return class-string<Attachment>
+     */
+    public static function attachmentModel(): string
+    {
+        $model = config('filament-media-library.model') ?? Attachment::class;
+
+        if (! is_a($model, Attachment::class, true)) {
+            throw InvalidConfiguration::modelIsNotValid($model);
+        }
+
+        return $model;
+    }
+
+    public static function attachmentModelInstance(): Attachment
+    {
+        $model = static::attachmentModel();
+
+        return new $model;
+    }
+
+    public static function attachmentQuery(): Builder
+    {
+        return static::attachmentModel()::query();
+    }
+}

--- a/src/Tables/Columns/AttachmentColumn.php
+++ b/src/Tables/Columns/AttachmentColumn.php
@@ -6,7 +6,7 @@ use Closure;
 use Filament\Tables\Columns\Column;
 use Filament\Tables\Columns\Concerns;
 use Illuminate\Support\Collection;
-use Wotz\MediaLibrary\Models\Attachment;
+use Wotz\MediaLibrary\Support\Config;
 
 class AttachmentColumn extends Column
 {
@@ -21,7 +21,7 @@ class AttachmentColumn extends Column
         $state = parent::getState();
 
         if (is_string($state)) {
-            $state = Attachment::find($state);
+            $state = Config::attachmentModel()::find($state);
         }
 
         $state = Collection::wrap($state)->pluck('id');
@@ -31,7 +31,7 @@ class AttachmentColumn extends Column
         }
 
         // Fetch the items again, otherwise we'll not have access to all our data
-        return Attachment::whereIn('id', $state)
+        return Config::attachmentQuery()->whereIn('id', $state)
             ->orderByRaw('FIELD(id, ' . $state->map(fn ($id) => "'{$id}'")->implode(',') . ')')
             ->get();
     }

--- a/tests/Fixtures/TestModels/CustomRootAttachment.php
+++ b/tests/Fixtures/TestModels/CustomRootAttachment.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Wotz\MediaLibrary\Tests\Fixtures\TestModels;
+
+use Wotz\MediaLibrary\Models\Attachment;
+
+/**
+ * The reason an application configures its own model: keeping an existing
+ * storage layout instead of moving every object to `attachments/`.
+ */
+class CustomRootAttachment extends Attachment
+{
+    public function getRootDirectoryAttribute(): string
+    {
+        return 'files';
+    }
+}

--- a/tests/Unit/Support/ConfigTest.php
+++ b/tests/Unit/Support/ConfigTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Wotz\MediaLibrary\Exceptions\InvalidConfiguration;
+use Wotz\MediaLibrary\Models\Attachment;
+use Wotz\MediaLibrary\Resources\AttachmentResource;
+use Wotz\MediaLibrary\Support\Config;
+use Wotz\MediaLibrary\Tests\Fixtures\TestModels\CustomRootAttachment;
+
+uses(RefreshDatabase::class);
+
+it('falls back to the packaged model', function () {
+    config()->set('filament-media-library.model', null);
+
+    expect(Config::attachmentModel())->toBe(Attachment::class)
+        ->and(Config::attachmentModelInstance())->toBeInstanceOf(Attachment::class);
+});
+
+it('returns the configured model', function () {
+    config()->set('filament-media-library.model', CustomRootAttachment::class);
+
+    expect(Config::attachmentModel())->toBe(CustomRootAttachment::class)
+        ->and(Config::attachmentModelInstance())->toBeInstanceOf(CustomRootAttachment::class);
+});
+
+it('rejects a model that is not an attachment', function () {
+    config()->set('filament-media-library.model', stdClass::class);
+
+    Config::attachmentModel();
+})->throws(InvalidConfiguration::class);
+
+it('queries through the configured model', function () {
+    config()->set('filament-media-library.model', CustomRootAttachment::class);
+
+    createAttachment(['id' => 1]);
+
+    expect(Config::attachmentQuery()->find(1))
+        ->toBeInstanceOf(CustomRootAttachment::class);
+});
+
+it('gives the resource the configured model', function () {
+    config()->set('filament-media-library.model', CustomRootAttachment::class);
+
+    expect(AttachmentResource::getModel())->toBe(CustomRootAttachment::class);
+});
+
+it('lets the configured model decide where files are stored', function () {
+    config()->set('filament-media-library.model', CustomRootAttachment::class);
+
+    createAttachment(['id' => 1]);
+
+    expect(Config::attachmentQuery()->find(1)->directory)
+        ->toBe('files/1');
+});


### PR DESCRIPTION
An application that already stores its media somewhere else needs attachments to keep their existing layout — above all the root directory, since moving objects in a bucket is the one step of a migration that is genuinely hard to reverse.

Subclassing `Attachment` did not achieve that. The package resolves its own model everywhere it queries or creates one, so a subclass applied to what the application read back and to nothing else — `UploadedFileMixin::firstOrCreate()` still wrote under `attachments/`, and `AttachmentResource` still listed the packaged model. On the project that prompted this, the media library's own index rendered URLs against a path that held nothing.

## What changed

- `Support\Config` resolves the model from `filament-media-library.model` and validates that it is an `Attachment`, in the same shape as [spatie/laravel-activitylog's `Support\Config`](https://github.com/spatie/laravel-activitylog/blob/main/src/Support/Config.php).
- Every call site that builds a query or creates a record goes through it — including `UploadedFileMixin`, so a configured model covers writes as well as reads.
- `AttachmentResource` resolves it in `getModel()`, which a static `$model` property could not.
- `AttachmentFormat` and `AttachmentVersion` point their `belongsTo` at the configured model.
- `Attachment` declares `$table` rather than leaving it to Laravel's guess from the class name, so a configured subclass can be called anything without pointing at a table that does not exist.

Defaults to the packaged model, so nothing changes for an application that does not set the key.

## Usage

```php
// config/filament-media-library.php
'model' => \App\Models\Attachment::class,
```

```php
class Attachment extends \Wotz\MediaLibrary\Models\Attachment
{
    public function getRootDirectoryAttribute(): string
    {
        return 'files';
    }
}
```

## Tests

`tests/Unit/Support/ConfigTest.php` covers the fallback, a configured model, an invalid one, the query builder, the resource, and that a configured model decides where files are stored. Full suite passes: 117 tests, 345 assertions.

## Companion PRs

Four sibling packages resolve `Wotz\MediaLibrary\Models\Attachment` directly and so ignore the configured model. Each has the same one-line change, and each pins its `wotz/filament-media-library` dependency to this branch so it resolves in the meantime — **those pins come back out before merge**. They should merge after this one is released:

- wotzebra/filament-seo#39 — `Tags/OpenGraphImage.php`
- wotzebra/filament-architect#48 — `MediaBlock`, `MediaTextBlock`, `SliderBlock`, `CardBlock`
- wotzebra/filament-image-or-video#35 — `Traits/ImageOrVideoUrl.php`
- wotzebra/filament-social-media-links#34 — `Views/Components/Overview.php`