### PR TITLE
Make the media grid usable: real breakpoints, card titles and a thumbnail fallback

### DIFF
--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -13,6 +13,7 @@ return [
     'height' => 'Height',
     'tags' => 'Tags',
     'image' => 'Image',
+    'preview unavailable' => 'Preview unavailable',
     'disk' => 'Disk',
     'format' => 'Format',
     'generate formats' => 'Generate formats',

--- a/resources/lang/nl/admin.php
+++ b/resources/lang/nl/admin.php
@@ -13,6 +13,7 @@ return [
     'height' => 'Hoogte',
     'tags' => 'Tags',
     'image' => 'Afbeelding',
+    'preview unavailable' => 'Voorbeeld niet beschikbaar',
     'disk' => 'Schijf',
     'format' => 'Formatteer',
     'generate formats' => 'Formaten genereren',

--- a/resources/views/components/attachment-list.blade.php
+++ b/resources/views/components/attachment-list.blade.php
@@ -1,24 +1,66 @@
 @php
+    use Illuminate\Support\Str;
+
     $attachment = $getRecord();
+    $isImage = $attachment->type === 'image';
+
+    // Alt text is the accessible name; fall back to the filename so the tile is never
+    // announced as an unnamed image.
+    $altText = filled($attachment->alt) ? $attachment->alt : $attachment->filename;
 @endphp
 
-<div class="
-    attachment-visual flex relative w-full aspect-square rounded-lg
-    overflow-hidden bg-gray-200 media mt-4
-    h-32 w-32 justify-center my-2
-">
-    @if ($attachment->type !== 'image')
-        <div class="w-full aspect-square flex items-center justify-center bg-gray-100 rounded-lg">
-            @if($attachment->type === 'document')
-                <x-heroicon-o-document-text class="w-16 h-16 opacity-50"/>
-            @elseif($attachment->type === 'video')
-                <x-heroicon-o-video-camera class="w-16 h-16 opacity-50"/>
+<div
+    @if ($isImage) x-data="{ failed: false }" @endif
+    class="
+        attachment-visual flex relative aspect-square rounded-lg
+        overflow-hidden bg-gray-100 dark:bg-white/5 media mt-4
+        h-32 w-32 items-center justify-center my-2
+    "
+>
+    @if (! $isImage)
+        <div class="flex h-full w-full flex-col items-center justify-center gap-y-1 text-gray-400 dark:text-gray-500">
+            @if ($attachment->type === 'document')
+                <x-filament::icon :icon="\Filament\Support\Icons\Heroicon::OutlinedDocumentText" class="h-10 w-10" />
+            @elseif ($attachment->type === 'video')
+                <x-filament::icon :icon="\Filament\Support\Icons\Heroicon::OutlinedVideoCamera" class="h-10 w-10" />
             @else
-                <x-heroicon-o-question-mark-circle class="w-16 h-16 opacity-50"/>
+                <x-filament::icon :icon="\Filament\Support\Icons\Heroicon::OutlinedQuestionMarkCircle" class="h-10 w-10" />
             @endif
+
+            <span class="px-2 text-center text-[0.625rem] font-medium uppercase tracking-wide">
+                {{ Str::upper($attachment->extension) }}
+            </span>
         </div>
     @else
-        <img src="{{ $attachment->getFormatOrOriginal('thumbnail') }}" />
+        {{--
+            A missing file otherwise renders the browser's broken-image glyph. Swap in a
+            styled placeholder instead.
+        --}}
+        <div
+            x-show="failed"
+            x-cloak
+            class="flex h-full w-full flex-col items-center justify-center gap-y-1 text-gray-400 dark:text-gray-500"
+        >
+            <x-filament::icon :icon="\Filament\Support\Icons\Heroicon::OutlinedPhoto" class="h-10 w-10" />
+
+            <span class="px-2 text-center text-[0.625rem] font-medium uppercase tracking-wide">
+                {{ __('filament-media-library::admin.preview unavailable') }}
+            </span>
+        </div>
+
+        <img
+            src="{{ $attachment->getFormatOrOriginal('thumbnail') }}"
+            alt="{{ $altText }}"
+            loading="lazy"
+            decoding="async"
+            @if ($attachment->width && $attachment->height)
+                width="{{ $attachment->width }}"
+                height="{{ $attachment->height }}"
+            @endif
+            x-show="! failed"
+            x-on:error="failed = true"
+            class="h-full w-full object-cover"
+        />
     @endif
 
     <abbr class="absolute inset-0 z-1" title="{{ $attachment->filename }}">

--- a/src/Models/Attachment.php
+++ b/src/Models/Attachment.php
@@ -26,6 +26,7 @@ use Wotz\MediaLibrary\Models\Traits\HasVersions;
  * @property int $size
  * @property string $extension
  * @property string $alt
+ * @property string $caption
  * @property string $translated_name
  * @property int|null $width
  * @property int|null $height

--- a/src/Resources/AttachmentResource.php
+++ b/src/Resources/AttachmentResource.php
@@ -17,6 +17,7 @@ use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\FontWeight;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters;
@@ -42,6 +43,15 @@ class AttachmentResource extends Resource
     public static function getNavigationLabel(): string
     {
         return __('filament-media-library::attachment.dashboard navigation title');
+    }
+
+    /**
+     * Without this the sidebar, page title and breadcrumb disagree: the navigation says
+     * "Media library" while the breadcrumb falls back to the model label, "Attachments".
+     */
+    public static function getBreadcrumb(): string
+    {
+        return static::getNavigationLabel();
     }
 
     public static function form(Schema $schema): Schema
@@ -118,8 +128,11 @@ class AttachmentResource extends Resource
         return $table
             ->defaultSort('created_at', 'desc')
             ->contentGrid([
-                'md' => 2,
-                'xl' => 4,
+                'sm' => 2,
+                'md' => 3,
+                'lg' => 4,
+                'xl' => 5,
+                '2xl' => 6,
             ])
             ->columns([
                 Tables\Columns\Layout\Grid::make([
@@ -128,13 +141,27 @@ class AttachmentResource extends Resource
 
                 TextColumn::make('name')
                     ->label(__('filament-media-library::admin.name'))
+                    ->weight(FontWeight::Bold)
                     ->sortable()
                     ->searchable(query: function ($query, string $search) {
                         return $query->search($search);
                     })
-                    ->getStateUsing(fn (Attachment $record) => new HtmlString(
-                        '<strong>' . Str::limit($record->name, 20) . '</strong>',
-                    )),
+                    /**
+                     * `name` is the stored UUID, which tells an editor nothing. Prefer the
+                     * alt text or caption when one has been filled in, and fall back to a
+                     * short slice of the UUID rather than 20 meaningless characters.
+                     */
+                    ->getStateUsing(fn (Attachment $record): string => filled($record->alt)
+                        ? $record->alt
+                        : (filled($record->caption)
+                            ? $record->caption
+                            : Str::before($record->name, '-') . '…'))
+                    ->tooltip(fn (Attachment $record): string => $record->filename)
+                    ->description(fn (Attachment $record): string => implode(' · ', array_filter([
+                        Str::upper($record->extension),
+                        $record->isImage() && $record->width ? "{$record->width}×{$record->height}" : null,
+                        "{$record->formattedInMbSize} MB",
+                    ]))),
 
                 TextColumn::make('tags')
                     ->label(__('filament-media-library::admin.tags'))


### PR DESCRIPTION
Found while auditing a Filament 5 panel that uses this package. Four independent issues in the media library index, all visible on the same screen.

## 1. The grid was stuck at two columns

`contentGrid(['md' => 2, 'xl' => 4])` — Filament's contentGrid breakpoints are **viewport**-based, not container-based. Once you subtract the panel sidebar, `xl` (1280px) is only reached on a genuinely wide screen, so a full-width media library renders **two** columns on any ordinary laptop while three quarters of the row sits empty.

Widened to `sm 2 / md 3 / lg 4 / xl 5 / 2xl 6`.

## 2. Every card was titled with a UUID

`name` is the stored UUID, so the column rendered `374b2e5e-a2ea-417b-9…` on every card — 20 characters of nothing, and no way to tell two images apart without opening them.

- Prefer `alt`, then `caption`, and only then fall back to a short UUID slice.
- New `description()` line with extension, dimensions and size (`JPEG · 1440×961 · 0.3 MB`).
- `tooltip()` carries the full filename.
- Dropped `HtmlString('<strong>' . … . '</strong>')` in favour of `->weight(FontWeight::Bold)`. Worth calling out: that wrapper skipped escaping, which was harmless for a UUID but not for `alt`/`caption`, which are user input.

## 3. Thumbnails had no `alt` and no fallback

`<img src="…" />` — no `alt` at all, so every image tile is an unnamed image to a screen reader. And when the underlying file is missing the browser's broken-image glyph shows through, which looks like a rendering bug rather than a missing asset.

- `alt` from the attachment's alt text, falling back to the filename.
- `x-on:error` swaps in a styled placeholder (photo icon + "Preview unavailable"). New translation key in `en` and `nl`.
- `loading="lazy"` + `decoding="async"` — the grid loads every thumbnail eagerly today.
- Intrinsic `width`/`height` so the grid stops reflowing as images arrive.
- Non-image tiles now show the extension under the icon, so a PDF and an XLSX are distinguishable.
- Raw `<x-heroicon-o-*>` components replaced with `<x-filament::icon>` + the `Heroicon` enum, and the tile got dark-mode variants — it was `bg-gray-200` / `bg-gray-100` with none.

## 4. Breadcrumb disagreed with the navigation

The sidebar and page title say "Media library" (via `getNavigationLabel()`), but the breadcrumb fell back to the model label and said "Attachments". `getBreadcrumb()` now defers to `getNavigationLabel()`.

I deliberately did *not* override `getPluralModelLabel()` — that would rename "Create attachment", bulk-action confirmations and the empty state too, which is a bigger change than this warrants.

## Notes

Tested against Filament v5.7.8 in light and dark mode.

https://claude.ai/code/session_017tkohR3qS2ngxsSFsyu8Sd